### PR TITLE
Fix extra slash in index dashboard link

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -504,7 +504,7 @@ var APP = APP || {};
 
                 // Make server call for dashboard info.
                 $.ajax({
-                    url: APP.Setup.get_base_path() + '/index.php/orion/get_dashboard_graphs',
+                    url: APP.Setup.get_base_path() + 'index.php/orion/get_dashboard_graphs',
                     type: 'GET',
                     data: {
                         dashboard: dashboard,


### PR DESCRIPTION
Without this loading the dashboard will result in a nice, and red embedded 404 error.

Request being something like
http://orion.xxxx.xxx//index.php/orion/get_dashboard_graphs?dashboard=Test&category=test
